### PR TITLE
Fix { singleError : false } for custom validators

### DIFF
--- a/src/amanda.js
+++ b/src/amanda.js
@@ -234,21 +234,25 @@
               validatorValue: propertyValidators[validatorName],
               message: error
             });
-            return (self.singleError) ? callback(true) : callback();
+            if (self.singleError) return callback(true);
           }
 
-          return callback();
+          if (callback) return callback();
 
         });
       } else {
-        return callback();
+        if (callback) return callback();
       }
     };
 
     if (propertyValidators.required !== true && typeof propertyValue === 'undefined') {
       return callback();
     } else {
-      return each(self.validators, iterator, callback);
+      if (self.singleError)
+        return each(self.validators, iterator, callback);
+      else
+        each(self.validators, iterator);
+        return callback()
     }
 
   };


### PR DESCRIPTION
This change fixes the problems where errors were not returned when `{ singleError : false }` is added to the `amanda.validate` function parameters.
