### PR TITLE
add functionality to set a custom error message

### DIFF
--- a/src/amanda.js
+++ b/src/amanda.js
@@ -227,6 +227,9 @@
         validatorFn(property, propertyValue, propertyValidators[validatorName], propertyValidators, function(error) {
 
           if (error) {
+            if(propertyValidators.hasOwnProperty('message')){
+              error = propertyValidators.message
+            }
             self.Errors.addError({
               property: property,
               propertyValue: propertyValue,

--- a/tests/customMessage.js
+++ b/tests/customMessage.js
@@ -1,0 +1,23 @@
+// Load dependencies
+var amanda = require('../src/amanda.js');
+
+exports['can set a custom error message'] = function(test){
+  var expected_error_message = 'age must be over zero.'
+  var person = {
+    type: 'object',
+    properties: {
+      age: {
+        type: 'number',
+        minimum: 10,
+        message: expected_error_message
+      }
+    }
+  }
+
+  amanda.validate({
+    age: 1
+  }, person, { singleError: false }, function(error) {
+    test.equal(error[0].message, expected_error_message)
+  })
+  test.done()
+};


### PR DESCRIPTION
When schema is defined, a custom error message can be passed as 'message' property.

How to use:

```
  var person = {
    type: 'object',
    properties: {
      age: {
        type: 'number',
        minimum: 10,
        message: 'your age must be over ten!'
      }
    }
  }
```
