### PR TITLE
Fixed minor documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ var schema = {
     name: {
       required: true,
       type: 'string',
-      length: [2, 45]
+      length: 7
     },
     email: {
       required: true,


### PR DESCRIPTION
As far as I can see in [the documentation](https://github.com/baggz/amanda#length) and [source code](https://github.com/Baggz/Amanda/blob/master/src/amanda.js#L768) the length parameter only accepts a number.
