### PR TITLE
fixed joinPath for attributes which are alphanumeric

### DIFF
--- a/src/engines/json/joinPath.js
+++ b/src/engines/json/joinPath.js
@@ -12,7 +12,7 @@ Validation.prototype.joinPath = function(path, property) {
   // Converts the ‘property’ to a string
   property = property + '';
 
-  if (property.match(/^[a-zA-Z]+$/)) {
+  if (property.match(/^[a-zA-Z][a-zA-Z0-9]*$/)) {
     return (path) ? (path + '.' + property) : property;
   } else if (property.match(/\d+/)) {
     return path + '[' + property + ']';


### PR DESCRIPTION
We found a pattern where attribute descriptions in error messages would occasionally be wrapped in brackets. It seemed to only occur when a number was in the attribute name. This led me to:

https://github.com/Baggz/Amanda/blob/master/src/engines/json/joinPath.js

The logic seems to intend to put numbers in brackets, aka 0 -> [0]; 1 -> [1], but and I think the lack of support for digits is an oversight.

Here is some example output:

``` javascript
{
  "error": {
    "0": {
      "property": "name",
      "propertyValue": "",
      "attributeName": "required",
      "attributeValue": true,
      "message": "The ‘name’ property is required.",
      "validator": "required",
      "validatorName": "required",
      "validatorValue": true
    },
    "1": {
      "property": "[street1]",
      "propertyValue": "",
      "attributeName": "required",
      "attributeValue": true,
      "message": "The ‘[street1]’ property is required.",
      "validator": "required",
      "validatorName": "required",
      "validatorValue": true
    },
    "2": {
      "property": "city",
      "propertyValue": "",
      "attributeName": "required",
      "attributeValue": true,
      "message": "The ‘city’ property is required.",
      "validator": "required",
      "validatorName": "required",
      "validatorValue": true
    },
    "3": {
      "property": "state",
      "propertyValue": "",
      "attributeName": "required",
      "attributeValue": true,
      "message": "The ‘state’ property is required.",
      "validator": "required",
      "validatorName": "required",
      "validatorValue": true
    },
    "length": 4,
    "errorMessages": {},
    "type": "validation"
  }
}
```

In this case, [street1] is erroneous.

The submitted fix should not surround an attribute in brackets if it is a valid javascript keyname -- alphanumeric, first character alpha-only.
