### PR TITLE
Fix required properties with zero value errors.

### DIFF
--- a/src/engines/json/getProperty.js
+++ b/src/engines/json/getProperty.js
@@ -6,7 +6,7 @@
  */
 Validation.prototype.getProperty = function(property, source) {
   if (source) {
-    return (source[property]) ? source[property] : undefined;
+    return (source[property] !== undefined) ? source[property] : undefined;
   } else {
     return undefined;
   }

--- a/tests/json/attributes/required/objects.js
+++ b/tests/json/attributes/required/objects.js
@@ -23,6 +23,10 @@ suite('JSON/Attribute/required#objects', function() {
           },
           surname: {
             required: true
+          },
+          age: {
+            required: true,
+            type: 'number'
           }
         }
       }
@@ -41,7 +45,8 @@ suite('JSON/Attribute/required#objects', function() {
     jsonSchemaValidator.validate({
       user: {
         name: 'František',
-        surname: 'Hába'
+        surname: 'Hába',
+        age: 0,
       }
     }, schema, function(error) {
       count += 1;


### PR DESCRIPTION
'required' properties that have a zero value generate an error when they should not. This is
due to if (source[property]) check in getProperty, instead of (source[property] !== undefined)
