### PR TITLE
fix of TypeError: Cannot read property '0' of undefined

### DIFF
--- a/src/engines/json/validateItems.js
+++ b/src/engines/json/validateItems.js
@@ -26,6 +26,11 @@ Validation.prototype.validateItems = function(instance, schema, path, callback) 
    *   ...
    * }
    */
+
+  if (isUndefined(instance)) {
+    instance = []
+  }
+
   if (isArray(schema.items)) {
 
     // Additional items are allowed


### PR DESCRIPTION
if array items are defined in schema and key is missing
f.e.:
schema:
{
    "type":"object",
    "$schema": "http://json-schema.org/draft-03/schema",
    "id": "http://jsonschema.net",
    "required":false,
    "properties":{
        "i": {
            "type":"array",
            "id": "http://jsonschema.net/i",
            "required":false,
            "items":[
                {
                    "type":"object",
                    "id": "http://jsonschema.net/i/0",
                    "required":false,
                    "properties":{
                        "1": {
                            "type":"number",
                            "id": "http://jsonschema.net/i/0/1",
                            "required":false
                        }
                    }
                },
                {
                    "type":"object",
                    "id": "http://jsonschema.net/i/1",
                    "required":false,
                    "properties":{
                        "3": {
                            "type":"number",
                            "id": "http://jsonschema.net/i/1/3",
                            "required":false
                        }
                    }
                }
            ]
        }
    }
}

---

data:
{
  "i_key_is_missing": []
}
